### PR TITLE
Improve UI and add friend settings

### DIFF
--- a/app/(tabs)/chat-select.tsx
+++ b/app/(tabs)/chat-select.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { Colors, Typography, Spacing, BorderRadius } from '@/constants/colors';
+import { useSettingsStore } from '@/store/settingsStore';
 
 type ChatOption = {
   id: string;
@@ -16,6 +17,8 @@ type ChatOption = {
 };
 
 export default function ChatSelectScreen() {
+  const { friendGender } = useSettingsStore();
+  const friendIcon = friendGender === 'girl' ? 'woman' : 'man';
   const chatOptions: ChatOption[] = [
     {
       id: 'doctor',
@@ -30,7 +33,7 @@ export default function ChatSelectScreen() {
       id: 'friend',
       title: 'むしむしフレンド',
       description: '虫が大好きな元気なお友達AIです。一緒に虫について楽しくおしゃべりしましょう！',
-      icon: 'happy',
+      icon: friendIcon,
       color: Colors.accent,
       route: '/chat',
       params: { chatType: 'friend' },

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, ScrollView, StyleSheet, SafeAreaView } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useBugStore } from '@/store/bugStore';
@@ -23,7 +24,7 @@ export default function HomeScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
       <ScrollView contentContainerStyle={styles.scrollContent}>
         {/* Header */}
         <View style={styles.header}>

--- a/app/(tabs)/notebook.tsx
+++ b/app/(tabs)/notebook.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, ScrollView, StyleSheet, SafeAreaView } from 'react-native';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useBugStore } from '@/store/bugStore';
@@ -14,7 +15,7 @@ export default function NotebookScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
       <ScrollView contentContainerStyle={styles.scrollContent}>
         {/* Header */}
         <View style={styles.header}>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
-import { View, Text, StyleSheet, SafeAreaView, TouchableOpacity, ScrollView } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { useBugStore } from '@/store/bugStore';
+import { useSettingsStore } from '@/store/settingsStore';
 import { Colors, Typography, Spacing, BorderRadius } from '@/constants/colors';
 
 export default function ProfileScreen() {
   const { bugs } = useBugStore();
+  const { friendGender, setFriendGender } = useSettingsStore();
 
   const stats = [
     { icon: 'bug', label: '発見した虫', value: bugs.length },
@@ -53,14 +56,25 @@ export default function ProfileScreen() {
     });
   };
 
+  const handleSettingsPress = () => {
+    Alert.alert('むしむしフレンドの設定', 'どちらを選びますか？', [
+      { text: '男の子', onPress: () => setFriendGender('boy') },
+      { text: '女の子', onPress: () => setFriendGender('girl') },
+      { text: 'キャンセル', style: 'cancel' },
+    ]);
+  };
+
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
       <ScrollView style={styles.content}>
         {/* Header */}
         <View style={styles.header}>
           <Text style={styles.title}>プロフィール</Text>
-          <Text style={styles.subtitle}>虫博士への道</Text>
+          <TouchableOpacity style={styles.settingsButton} onPress={handleSettingsPress}>
+            <Ionicons name="settings" size={24} color={Colors.primary} />
+          </TouchableOpacity>
         </View>
+        <Text style={styles.subtitle}>虫博士への道</Text>
 
         {/* Avatar */}
         <View style={styles.avatarContainer}>
@@ -146,8 +160,10 @@ const styles = StyleSheet.create({
     padding: Spacing.lg,
   },
   header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: Spacing.xl,
+    marginBottom: Spacing.sm,
   },
   title: {
     fontSize: Typography.extraLarge,
@@ -159,6 +175,10 @@ const styles = StyleSheet.create({
     fontSize: Typography.medium,
     color: Colors.gray,
     textAlign: 'center',
+    marginBottom: Spacing.xl,
+  },
+  settingsButton: {
+    padding: Spacing.sm,
   },
   avatarContainer: {
     alignItems: 'center',

--- a/app/(tabs)/quiz.tsx
+++ b/app/(tabs)/quiz.tsx
@@ -85,19 +85,19 @@ export default function QuizScreen() {
     setShowResult(true);
 
     // 結果表示アニメーション
-    Animated.sequence([
-      Animated.timing(resultAnimation, {
-        toValue: 1,
-        duration: 300,
-        useNativeDriver: true,
-      }),
-      Animated.timing(resultAnimation, {
-        toValue: 0,
-        duration: 200,
-        delay: 2000,
-        useNativeDriver: true,
-      }),
-    ]).start();
+    Animated.timing(resultAnimation, {
+      toValue: 1,
+      duration: 300,
+      useNativeDriver: true,
+    }).start(() => {
+      setTimeout(() => {
+        Animated.timing(resultAnimation, {
+          toValue: 0,
+          duration: 300,
+          useNativeDriver: true,
+        }).start();
+      }, 1500);
+    });
 
     if (answerIndex === currentQuestion.correctAnswer) {
       setScore(score + 1);
@@ -400,22 +400,22 @@ const styles = StyleSheet.create({
   },
   resultOverlay: {
     position: 'absolute',
-    top: '40%',
+    top: '50%',
     left: '50%',
-    transform: [{ translateX: -75 }, { translateY: -75 }],
+    transform: [{ translateX: -50 }, { translateY: -50 }],
     zIndex: 1000,
   },
   resultBadge: {
-    width: 150,
-    height: 150,
-    borderRadius: 75,
+    width: 100,
+    height: 100,
+    borderRadius: 50,
     justifyContent: 'center',
     alignItems: 'center',
     shadowColor: Colors.shadow,
     shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
-    elevation: 8,
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    elevation: 4,
   },
   correctBadge: {
     backgroundColor: Colors.success,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,13 +1,15 @@
 import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { View } from 'react-native';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
+import { Colors } from '@/constants/colors';
 
 export default function RootLayout() {
   useFrameworkReady();
 
   return (
-    <>
+    <View style={{ flex: 1, backgroundColor: Colors.background }}>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="(tabs)" />
         <Stack.Screen name="capture" />
@@ -17,7 +19,7 @@ export default function RootLayout() {
         <Stack.Screen name="achievement" />
         <Stack.Screen name="+not-found" />
       </Stack>
-      <StatusBar style="auto" />
-    </>
+      <StatusBar style="dark" backgroundColor={Colors.background} />
+    </View>
   );
 }

--- a/app/chat.tsx
+++ b/app/chat.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, ScrollView, TextInput, TouchableOpacity, StyleSheet, KeyboardAvoidingView, Platform, Alert } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { chatWithBugDoctor, chatWithFriend } from '@/services/mockApi';
@@ -29,6 +29,7 @@ export default function ChatScreen() {
   const [chatHistory, setChatHistory] = useState<ChatTurn[]>([]);
   const [inputText, setInputText] = useState('');
   const [loading, setLoading] = useState(false);
+  const insets = useSafeAreaInsets();
   const { addBug, bugs } = useBugStore();
 
   // Check if this bug is already in the collection
@@ -163,6 +164,7 @@ export default function ChatScreen() {
       <KeyboardAvoidingView
         style={styles.keyboardAvoid}
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={insets.bottom}
       >
         {/* Header */}
         <View style={styles.header}>

--- a/components/ChatBubble.tsx
+++ b/components/ChatBubble.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { View, Text, Image, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { ChatTurn } from '@/types';
 import { Colors, Typography, Spacing, BorderRadius } from '@/constants/colors';
+import { useSettingsStore } from '@/store/settingsStore';
 
 interface ChatBubbleProps {
   turn: ChatTurn;
@@ -9,17 +11,26 @@ interface ChatBubbleProps {
   chatType?: 'doctor' | 'friend';
 }
 
-const DOCTOR_AVATAR = 'https://images.pexels.com/photos/1108572/pexels-photo-1108572.jpeg?auto=compress&cs=tinysrgb&w=200';
-const FRIEND_AVATAR = 'https://images.pexels.com/photos/326055/pexels-photo-326055.jpeg?auto=compress&cs=tinysrgb&w=200';
+const DOCTOR_ICON = 'man';
 
 export default function ChatBubble({ turn, isLast = false, chatType = 'doctor' }: ChatBubbleProps) {
+  const { friendGender } = useSettingsStore();
   const isBot = turn.role === 'doctor' || turn.role === 'friend';
-  const avatar = turn.role === 'friend' ? FRIEND_AVATAR : DOCTOR_AVATAR;
+  const iconName = turn.role === 'doctor'
+    ? DOCTOR_ICON
+    : friendGender === 'girl'
+      ? 'woman'
+      : 'man';
 
   return (
     <View style={[styles.container, isLast && styles.lastMessage]}>
       {isBot && (
-        <Image source={{ uri: avatar }} style={styles.avatar} />
+        <View style={[
+          styles.avatar,
+          turn.role === 'friend' ? styles.friendAvatar : styles.doctorAvatar,
+        ]}>
+          <Ionicons name={iconName as any} size={20} color={Colors.white} />
+        </View>
       )}
       <View
         style={[
@@ -56,7 +67,14 @@ const styles = StyleSheet.create({
     height: 32,
     borderRadius: 16,
     marginRight: Spacing.sm,
-    backgroundColor: Colors.lightGray,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  doctorAvatar: {
+    backgroundColor: Colors.doctorBubble,
+  },
+  friendAvatar: {
+    backgroundColor: Colors.accent,
   },
   bubble: {
     maxWidth: '75%',

--- a/store/settingsStore.ts
+++ b/store/settingsStore.ts
@@ -1,0 +1,7 @@
+import { create } from 'zustand';
+import { SettingsStore } from '@/types';
+
+export const useSettingsStore = create<SettingsStore>((set) => ({
+  friendGender: 'boy',
+  setFriendGender: (gender) => set({ friendGender: gender }),
+}));

--- a/types/index.ts
+++ b/types/index.ts
@@ -27,3 +27,8 @@ export type BugStore = {
   updateBugNotes: (id: string, notes: string) => void;
   getBugById: (id: string) => Bug | undefined;
 };
+
+export type SettingsStore = {
+  friendGender: 'boy' | 'girl';
+  setFriendGender: (gender: 'boy' | 'girl') => void;
+};


### PR DESCRIPTION
## Summary
- update layout to have consistent background color
- support safe area edges for major screens
- simplify quiz result animation and overlay styling
- add settings store and profile option for friend gender
- show friend gender in chat select and chat bubbles
- adjust keyboard handling in chat screen

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_686bd63a1868832ca9f6f4c3cb6e80a7