### PR TITLE
feat: ガチャ機能の改善

### DIFF
--- a/app/(tabs)/gacha/[results].tsx
+++ b/app/(tabs)/gacha/[results].tsx
@@ -163,6 +163,12 @@ export default function GachaResults() {
 
         <View style={styles.pointsContainer}>
           <Text style={styles.pointsText}>{getPointsText()}</Text>
+          {result === 'jackpot' && (
+            <Image source={require('@/assets/images/rainbowticket.png')} style={styles.ticketIcon} />
+          )}
+          {result === 'win' && (
+            <Image source={require('@/assets/images/goldticket.png')} style={styles.ticketIcon} />
+          )}
         </View>
 
         {showResult && article && (
@@ -182,6 +188,7 @@ export default function GachaResults() {
             style={styles.button}
             onPress={() => router.push('/gacha/movie')}
           >
+            <Image source={require('@/assets/images/mushidama.png')} style={styles.buttonIcon} />
             <Text style={styles.buttonText}>もう一度ガチャを回す</Text>
           </TouchableOpacity>
 
@@ -233,6 +240,13 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderRadius: 25,
     marginBottom: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  ticketIcon: {
+    width: 32,
+    height: 32,
   },
   pointsText: {
     color: 'white',
@@ -270,6 +284,14 @@ const styles = StyleSheet.create({
     paddingHorizontal: 30,
     borderRadius: 10,
     alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 10,
+  },
+  buttonIcon: {
+    width: 32,
+    height: 32,
+    padding: 8,
   },
   buttonText: {
     color: 'white',

--- a/app/(tabs)/gacha/index.tsx
+++ b/app/(tabs)/gacha/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native';
 import { router } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -11,9 +11,7 @@ export default function GachaScreen() {
 
   const handleDraw = async () => {
     if (!consumePoints(10)) return;
-    router.push({
-      pathname: '/gacha/movie',
-    });
+    router.push('/gacha/movie');
   };
 
   return (
@@ -25,7 +23,7 @@ export default function GachaScreen() {
           onPress={handleDraw}
           activeOpacity={0.8}
         >
-          <Ionicons name="gift" size={40} color={Colors.white} />
+          <Image source={require('@/assets/images/mushidama.png')} style={styles.buttonIcon}/>
           <Text style={styles.buttonText}>ガチャを回す (10pt)</Text>
         </TouchableOpacity>
       </View>
@@ -51,7 +49,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
   button: {
-    backgroundColor: Colors.accent,
+    backgroundColor: '#3dba8e',
     borderRadius: BorderRadius.large,
     paddingHorizontal: Spacing.xl,
     paddingVertical: Spacing.lg,
@@ -59,6 +57,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: Spacing.sm,
     marginBottom: Spacing.lg,
+  },
+  buttonIcon: {
+    width: 32,
+    height: 32,
   },
   buttonText: {
     color: Colors.white,

--- a/app/(tabs)/gacha/movie.tsx
+++ b/app/(tabs)/gacha/movie.tsx
@@ -51,38 +51,38 @@ export default function GachaMovie() {
 
   // 動画準備完了を監視
   useEffect(() => {
-    if ((status as string) === 'readyToPlay' && isLooping) {
+    if ((status as string) === 'readyToPlay') {
       setIsReady(true);
+      player.play();
     }
-  }, [status, isLooping]);
+  }, [status]);
 
-  // 準備できたら1/5区間ループ再生
+  // 動画の時間更新を監視
   useEventListener(player, 'timeUpdate', ({ currentTime }) => {
-    // 押下前のループ
-    if (isLooping && player.duration && currentTime >= player.duration / 5) {
-      player.currentTime = 0;
+    if (!player.duration) return;
+    
+    // ループ中は3.4秒でリセット
+    if (isLooping && currentTime >= 3.4) {
+      player.currentTime = 1.3;
+      player.play();
       return;
     }
-    // 押下後の完了判定 → 遷移
-    if (
-      !isLooping &&
-      player.duration &&
-      currentTime >= player.duration &&
-      !hasNavigated
-    ) {
+    
+    // ボタン押下後は最後まで再生して遷移
+    if (!isLooping && currentTime >= player.duration && !hasNavigated) {
       setHasNavigated(true);
       router.push(`/gacha/${gachaResult}`);
     }
   });
 
-  // 1/5区間でループ
+  // 3.4秒でループ
   useEffect(() => {
     if (
       isLooping &&
       player.duration > 0 &&
-      player.currentTime >= player.duration / 5
+      player.currentTime >= 3.4
     ) {
-      player.currentTime = 0;
+      player.currentTime = 3.4;
       player.play();
     }
   }, [player.currentTime, isLooping]);
@@ -121,10 +121,14 @@ export default function GachaMovie() {
       </TouchableWithoutFeedback>
       {isLooping && (
         <TouchableOpacity
-          onPress={() => setIsLooping(false)}
+          onPress={() => {
+            setIsLooping(false);
+            player.currentTime = 3.4;
+            player.play();
+          }}
           style={styles.button}
         >
-          <Text style={styles.buttonText}>ガチャを回す</Text>
+          <Text style={styles.buttonText}></Text>
         </TouchableOpacity>
       )}
     </View>
@@ -141,16 +145,22 @@ const styles = StyleSheet.create({
     width: '100%', // 幅いっぱいに表示
     height: '100%', // 高さいっぱいに表示
   },
-  button: {
-    backgroundColor: '#3dba8e',
-    paddingHorizontal: 20,
-    paddingVertical: 10,
-    borderRadius: 8,
-    zIndex: 1000,
-    position: 'absolute',
-    bottom: 60,
-    alignSelf: 'center',
-  },
+button: {
+  backgroundColor: 'transparent',
+  paddingHorizontal: 20,
+  paddingVertical: 10,
+  borderRadius: 8,
+  zIndex: 1000,
+  position: 'absolute',
+  bottom: 60,
+  alignSelf: 'center',
+
+  // 追加: 画面全体に広げる
+  width: '100%',
+  height: '100%',
+  justifyContent: 'center',
+  alignItems: 'center',
+},
   buttonText: {
     color: 'white',
     fontSize: 16,


### PR DESCRIPTION
- 動画のループ時間を1.3~3.4秒に変更
- ガチャ結果画面にチケット画像を追加
- ボタンにmushidama.png画像を追加
- 画面全体をタップでガチャ可能に変更
- UI/UXの統一